### PR TITLE
Fixing 404 & 500 pages to respond properly and get entry content

### DIFF
--- a/templates/404.twig
+++ b/templates/404.twig
@@ -1,5 +1,8 @@
 {% import "/_macros" as macros %}
 {% extends "_layouts/main" %}
+
+{% set entry = craft.entries.section('notFoundPage').one %}
+	
 {% block content %}
     <!-- Main jumbotron for a primary marketing message or call to action -->
     <div class="jumbotron">

--- a/templates/500.twig
+++ b/templates/500.twig
@@ -1,5 +1,8 @@
 {% import "/_macros" as macros %}
 {% extends "_layouts/main" %}
+
+{% set entry = craft.entries.section('errorPage').one %}
+
 {% block content %}
     <!-- Main jumbotron for a primary marketing message or call to action -->
     <div class="jumbotron">


### PR DESCRIPTION
404 & 500 templates need to be names without the leading underscore. Also need to set the entry in the template to get the entry's content when the pages respond as actual 404 and 500 pages.