### PR TITLE
Update DB instructions link to v3 Craft docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm install
 npm run dev
 ```
 
-[Create your database](https://craftcms.com/docs/installing#step-3-create-your-database) and ensure the settings in your `.env` match your environment. At minimum, you'll need to tell Craft how to connect to your database and your domain. Then run the installer by going to /admin (except for your domain.)
+[Create your database](https://docs.craftcms.com/v3/installation.html#step-4-create-a-database) and ensure the settings in your `.env` match your environment. At minimum, you'll need to tell Craft how to connect to your database and your domain. Then run the installer by going to /admin (except for your domain.)
 
 Optionally, you can import the supplied `padstone.sql` file into your database if you want Padstone's starter entries.
 


### PR DESCRIPTION
Was playing around with your starter package, and hit a speed bump when I didn't notice that the 'create your database' link in the README linked to Craft v2 docs. Sorry if it's presumptuous to send a pull request -- just figured others diving in for the first time might get confused like I did by the old docs.