### PR TITLE
Updating responsive image partial to fix transform bug

### DIFF
--- a/templates/_partials/responsiveImage.twig
+++ b/templates/_partials/responsiveImage.twig
@@ -12,7 +12,7 @@
 {% endif %}
 
 {% set srcset = asset.getSrcset(sizes) %}
-{% do asset.setTransform(transform|merge({ format: 'webp' })) %}
+{% do asset.setTransform({transform: transform}|merge({ format: 'webp' })) %}
 {% set webpSrcset = asset.getSrcset(sizes) %}
 
 <picture class="{{ pictureClass }}">


### PR DESCRIPTION
I've made the fix to make the responsive image work with Craft transforms, and tested it with objects like  { width: 100, mode: 'crop' } as well