### PR TITLE
enable mediaEmbed.previewsInData for CKEditor

### DIFF
--- a/config/project/ckeditor/configs/c164bcf4-0226-4e9f-bfe0-ca08ad8056b5.yaml
+++ b/config/project/ckeditor/configs/c164bcf4-0226-4e9f-bfe0-ca08ad8056b5.yaml
@@ -18,6 +18,8 @@ options:
           target: _blank
         label: 'Open in a new tab'
         mode: manual
+  mediaEmbed:
+    previewsInData: true
 toolbar:
   - heading
   - '|'
@@ -29,4 +31,5 @@ toolbar:
   - insertImage
   - undo
   - redo
+  - mediaEmbed
   - htmlEmbed

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1747847835
+dateModified: 1747855725
 email:
   fromEmail: info@imarc.com
   fromName: 'Padstone Craft 5'


### PR DESCRIPTION
Enables a feature within CKEditor to include previews for YouTube, Vimeo and a couple others in the front end instead of just the <oembed> code:

* https://ckeditor.com/docs/ckeditor5/latest/features/media-embed.html#including-previews-in-data
* https://ckeditor.com/docs/ckeditor5/latest/features/media-embed.html#media-providers

It does require some CSS hackery to be added to pronto too, but I've done that and I can get that into Pronto.
